### PR TITLE
Modifying for use on non-OSPool HTCondor pools

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -113,6 +113,17 @@ def parse_cla() -> argparse.Namespace:
         + "should be a float between 0.0 (exclusive) and 1.0 (inclusive).",
     )
 
+    parser.add_argument(
+        "-cm",
+        "--central-manager",
+        metavar="cm.pool.domain",
+        dest="central_manager",
+        type=str,
+        default="cm-1.ospool.osg-htc.org",
+        help="Specifies the address of the HTCondor Central Manager."
+        + "Used for querying the resources available in the corresponding HTC pool."
+    )
+
     return parser.parse_args()
 
 

--- a/tests/basic-cpu/basic-cpu.sub
+++ b/tests/basic-cpu/basic-cpu.sub
@@ -12,6 +12,4 @@ request_cpus = 1
 request_memory = 1GB
 request_disk = 1GB
 
-should_transfer_files = no
-
 queue

--- a/tests/basic-cpu/basic-cpu.sub
+++ b/tests/basic-cpu/basic-cpu.sub
@@ -1,0 +1,17 @@
+# Simple submit file for testing the pool exerciser on the CHTC
+
+executable = /bin/hostname
+transfer_executable = False
+arguments = -f
+
+output = $(sample_dir)/basic-cpu.out
+error = $(sample_dir)/basic-cpu.err
+log = basic-cpu.log
+
+request_cpus = 1
+request_memory = 1GB
+request_disk = 1GB
+
+should_transfer_files = no
+
+queue


### PR DESCRIPTION
Generally, modifications involved being able to specify the central manager of the pool to test, and the corresponding resource name.

Does make the assumption that if its a non-OSPool pool, then the classad corresponding to the resource name is "Machine". 
This behavior should be easy to change by modifying the `src.general.get_resource_classad()` function.
Perhaps a better approach would be to make a CLI argument to allow the user to pass the classad they want to use instead.

Motivated by desire to be able to use the pool exerciser on CHTC.

